### PR TITLE
Accept command-line arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,11 @@ func main() {
 
 	flag.Parse()
 
+	if flag.NArg() != 2 {
+		fmt.Println("You must supply a username and API key after all other args.")
+		os.Exit(1)
+	}
+
 	username, apiKey := flag.Arg(0), flag.Arg(1)
 
 	opts := gophercloud.AuthOptions{

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"time"
@@ -11,7 +12,11 @@ import (
 )
 
 func main() {
-	username, apiKey := "", ""
+	outputCSV := flag.Bool("-csv", false, "Output a CSV file")
+
+	flag.Parse()
+
+	username, apiKey := flag.Arg(0), flag.Arg(1)
 
 	opts := gophercloud.AuthOptions{
 		Username: username,

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ import (
 )
 
 func main() {
-	outputCSV := flag.Bool("-csv", false, "Output a CSV file")
+	outputCSV := *flag.Bool("csv", false, "Output a CSV file")
+	useLocaltime := *flag.Bool("localtime", false, "Use local timestamps instead of UTC")
 
 	flag.Parse()
 
@@ -32,6 +33,10 @@ func main() {
 
 	fmt.Printf("Regions with a compute endpoint: %#v\n", regions)
 
+	if useLocaltime {
+		fmt.Println("Dummy switch so Go shuts up about unused variables!")
+	}
+
 	// Iterate through regions
 
 	// Iterate through servers in each region
@@ -39,6 +44,9 @@ func main() {
 	// Pull the metadata key
 
 	// Output a CSV row
+	if outputCSV {
+		fmt.Println("I would be writing a CSV file here!")
+	}
 }
 
 // Regions acquires the service catalog and returns a slice of every region that contains a first-


### PR DESCRIPTION
Parse the requested command-line arguments.

`cs-reboot-info --csv --localtime username apikey`

Binary name: 
cs-reboot-info 
CSV output (optional)
--csv 
Local/system time zone conversion from UTC (optional)
--localtime
Cloud Servers API username
username 
Cloud Servers API Key
apikey